### PR TITLE
Fixes #75 and Fixes #76

### DIFF
--- a/src/Migrations/AppMigrations/20230823005838_AlterGamesAndTourn.Designer.cs
+++ b/src/Migrations/AppMigrations/20230823005838_AlterGamesAndTourn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PingPongTracker.Data;
 
@@ -11,9 +12,11 @@ using PingPongTracker.Data;
 namespace PingPongTracker.Migrations.AppMigrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230823005838_AlterGamesAndTourn")]
+    partial class AlterGamesAndTourn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Migrations/AppMigrations/20230823005838_AlterGamesAndTourn.cs
+++ b/src/Migrations/AppMigrations/20230823005838_AlterGamesAndTourn.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PingPongTracker.Migrations.AppMigrations
+{
+    /// <inheritdoc />
+    public partial class AlterGamesAndTourn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Games_Tournaments_TournamentId",
+                table: "Games");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "TournamentId",
+                table: "Games",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Games_Tournaments_TournamentId",
+                table: "Games",
+                column: "TournamentId",
+                principalTable: "Tournaments",
+                principalColumn: "TournamentId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Games_Tournaments_TournamentId",
+                table: "Games");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "TournamentId",
+                table: "Games",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Games_Tournaments_TournamentId",
+                table: "Games",
+                column: "TournamentId",
+                principalTable: "Tournaments",
+                principalColumn: "TournamentId");
+        }
+    }
+}

--- a/src/Models/Game.cs
+++ b/src/Models/Game.cs
@@ -24,4 +24,6 @@ public class Game
     public Guid Player1WinnerId { get; set; }
     [Required]
     public Guid Player2WinnerId { get; set; }
+
+    public Tournament Tournament { get; set; } = new();
 }

--- a/src/Models/Tournament.cs
+++ b/src/Models/Tournament.cs
@@ -10,7 +10,6 @@ public class Tournament
     public DateTime TournamentDate { get; set; }
     public string Location { get; set; } = string.Empty;
     
-    public List<Player> Players { get; set; } = new();
-    public List<Game> Games { get; set; } = new();
+    public List<Player> Players { get; set; } = new();    
 
 }

--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -14,12 +14,51 @@
 <br />
 
 <div class="text-center">
-    <h2>Current Season: @Model.SeasonTitle @Model.SeasonStartDate </h2>
+    <h2>Current Season: <span class="maintitle">@Model.SeasonTitle</span> @Model.SeasonStartDate </h2>
 </div>
 <br />
 
+@if(@Model.CurrentSeason is not null)
+{
+    <div>
+        <div class="text-center">
+            <h3>Standings</h3>
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th scope="col">Rank</th>
+                        <th scope="col">Player</th>
+                        <th scope="col">Wins</th>
+                        <th scope="col">Losses</th>
+                        <th scope="col">Total Games</th>
+                        <th scope="col">Win %</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var player in Model.SeasonStandings)
+                    {
+                        <tr>
+                            <th scope="row">@player.Rank</th>
+                            <td>@player.UserName</td>
+                            <td>@player.Wins</td>
+                            <td>@player.Losses</td>
+                            <td>@player.TotalGames</td>
+                            <td>@player.WinPercentage</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+<br />
+<br />
+<br />
+<br />
+
 <div class="text-center">
-    <h3>Standings</h3>
+    <h3>All-Time Standings</h3>
     <table class="table table-striped">
         <thead>
             <tr>
@@ -32,7 +71,7 @@
             </tr>
         </thead>
         <tbody>
-            @foreach (var player in Model.Players)
+            @foreach (var player in Model.AllTimeStandings)
             {
                 <tr>
                     <th scope="row">@player.Rank</th>
@@ -44,4 +83,5 @@
                 </tr>
             }
         </tbody>
+    </table>
 </div>


### PR DESCRIPTION
Distinguishes between seasonal and all-time standings. Hides seasonal standings when no season active.
Created new migration to alter relation between Tounaments and Games Added font to season name